### PR TITLE
Fix fs.writeFile warnings thrown in NodeJS 7

### DIFF
--- a/webpack-utf8-bom.js
+++ b/webpack-utf8-bom.js
@@ -34,7 +34,9 @@ UTF8BOMPlugin.prototype.apply = function(compiler) {
         
           var bom = new Buffer([0xEF, 0xBB, 0xBF]);
           buff = bom + buff;
-          fs.writeFile(path, buff.toString(), "utf8");
+          fs.writeFile(path, buff.toString(), "utf8", function(err) {
+            console.error(err);
+          });
           
         }
                 
@@ -45,7 +47,9 @@ UTF8BOMPlugin.prototype.apply = function(compiler) {
           && buff[1].toString(16).toLowerCase() == "bb" 
           && buff[2].toString(16).toLowerCase() == "bf") {          
           buff = buff.slice(3);
-          fs.writeFile(path, buff.toString(), "utf8");
+          fs.writeFile(path, buff.toString(), "utf8", function(err) {
+            console.error(err);
+          });
         }
       }
       

--- a/webpack-utf8-bom.js
+++ b/webpack-utf8-bom.js
@@ -35,7 +35,7 @@ UTF8BOMPlugin.prototype.apply = function(compiler) {
           var bom = new Buffer([0xEF, 0xBB, 0xBF]);
           buff = bom + buff;
           fs.writeFile(path, buff.toString(), "utf8", function(err) {
-            console.error(err);
+            if (err) throw err;
           });
           
         }
@@ -48,7 +48,7 @@ UTF8BOMPlugin.prototype.apply = function(compiler) {
           && buff[2].toString(16).toLowerCase() == "bf") {          
           buff = buff.slice(3);
           fs.writeFile(path, buff.toString(), "utf8", function(err) {
-            console.error(err);
+            if (err) throw err;
           });
         }
       }


### PR DESCRIPTION
NodeJS 7 and above throws warnings (eg: DeprecationWarning: Calling an asynchronous function without callback is deprecated.) when an async function is called without supplying callback. I have added a callback which throws error if writing files to disk fails.